### PR TITLE
Proguard fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ You can apply a new look by changing the color of certain parts of the UI to hig
 ## Configuring Proguard
 To configure Proguard, add the following lines to your proguard configuration file. These will keep files related to this sdk
 ```
-keepclasseswithmembers public class com.flutterwave.raveandroid.** { *; }
-dontwarn com.flutterwave.raveandroid.card.CardFragment
+-keepclasseswithmembers public class com.flutterwave.raveandroid.** { *; }
+-dontwarn com.flutterwave.raveandroid.card.CardFragment
 ```
 
 

--- a/raveandroid/build.gradle
+++ b/raveandroid/build.gradle
@@ -18,7 +18,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            consumerProguardFiles 'consumer-proguard-rules.pro'
         }
     }
 }

--- a/raveandroid/consumer-proguard-rules.pro
+++ b/raveandroid/consumer-proguard-rules.pro
@@ -1,0 +1,27 @@
+-dontwarn okhttp3.**
+-dontwarn okio.**
+-dontwarn javax.annotation.**
+-dontwarn org.conscrypt.**
+-dontwarn com.squareup.picasso.**
+-dontnote retrofit2.Platform
+-dontwarn retrofit2.Platform$Java8
+-keepattributes Signature
+-keepattributes Exceptions
+
+#-keepclassmembernames interface * {
+#    @retrofit2.http.* <methods>;
+#}
+-keepclasseswithmembers class * {
+    @retrofit2.* <methods>;
+}
+
+-keepclasseswithmembers interface * {
+    @retrofit2.* <methods>;
+}
+
+-keep interface org.parceler.Parcel
+-keep @org.parceler.Parcel class * { *; }
+-keep class **$$Parcelable { *; }
+
+-keepclasseswithmembers public class com.flutterwave.raveandroid.** { *; }
+-dontwarn com.flutterwave.raveandroid.card.CardFragment


### PR DESCRIPTION
Current proguard configurations in readme dosen't cater for the library dependencies. There is no way for developers trying to integrate the library to know which proguard configurations to add if they are using proguard until they try to make a release build or dig into the library's codebase. 

This PR adds a consumer-proguard-rules file to automatically add these proguard configs so devs integrating don't have to worry about proguard configs of dependencies they are not directly using. If you don't agree with this approach anyways, then the full proguard configs should be listed in the readme as it is in the consumer-proguards-rules.pro file.