### PR TITLE
Add checks for displaying currency-specific payment methods

### DIFF
--- a/raveandroid/src/main/java/com/flutterwave/raveandroid/RavePayActivity.java
+++ b/raveandroid/src/main/java/com/flutterwave/raveandroid/RavePayActivity.java
@@ -109,15 +109,15 @@ public class RavePayActivity extends AppCompatActivity {
             }
         }
 
-        if (ravePayInitializer.isWithMpesa()) {
+        if (ravePayInitializer.isWithMpesa() && ravePayInitializer.getCurrency().equalsIgnoreCase("KES")) {
             raveFragments.add(new RaveFragment(new MpesaFragment(), "Mpesa"));
         }
 
-        if (ravePayInitializer.isWithGHMobileMoney()) {
+        if (ravePayInitializer.isWithGHMobileMoney() && ravePayInitializer.getCurrency().equalsIgnoreCase("GHS")) {
             raveFragments.add(new RaveFragment(new GhMobileMoneyFragment(), "GHANA MOBILE MONEY"));
         }
 
-        if (ravePayInitializer.isWithUgMobileMoney()) {
+        if (ravePayInitializer.isWithUgMobileMoney() && ravePayInitializer.getCurrency().equalsIgnoreCase("UGX")) {
             raveFragments.add(new RaveFragment(new UgMobileMoneyFragment(), "UGANDA MOBILE MONEY"));
         }
 


### PR DESCRIPTION
Some payment methods are only available for specific currencies (Mobile money types). It won't make sense to display them for other currencies, it will just be throwing errors when they try to pay.