### PR TITLE
Change Base URL

### DIFF
--- a/raveandroid/src/main/java/com/flutterwave/raveandroid/RaveConstants.java
+++ b/raveandroid/src/main/java/com/flutterwave/raveandroid/RaveConstants.java
@@ -10,10 +10,10 @@ public class RaveConstants {
     public static String PUBLIC_KEY = "FLWPUBK-e634d14d9ded04eaf05d5b63a0a06d2f-X"; //test
     public static String ENCRYPTION_KEY = "bb9714020722eb4cf7a169f2";
     //    public static String STAGING_URL = "https://ravesandbox.azurewebsites.net";
-    public static String LIVE_URL = "https://raveapi.azurewebsites.net";
+//    public static String LIVE_URL = "https://raveapi.azurewebsites.net";
     //Todo: change back BAse URL
     public static String STAGING_URL = "https://ravesandboxapi.flutterwave.com";
-    //  public static String LIVE_URL = "https://api.ravepay.co";
+    public static String LIVE_URL = "https://api.ravepay.co";
 
     public static String VBV = "VBVSECURECODE";
     public static String GTB_OTP = "GTB_OTP";


### PR DESCRIPTION
The former base URL we were using (raveapi.azurewebsites...) seems to be out of date. Some functions do not work well with it, like the setting duration for pay with bank transfer.
Better for us to go with the endpoints Rave uses.