### PR TITLE
Catch Rave Auth Model switching

### DIFF
--- a/raveandroid/src/main/java/com/flutterwave/raveandroid/card/CardContract.java
+++ b/raveandroid/src/main/java/com/flutterwave/raveandroid/card/CardContract.java
@@ -59,8 +59,6 @@ public interface CardContract {
 
         void onTokenRetrieved(String flwRef, String cardBIN, String token);
 
-        void onAVSVBVSecureCodeModelUsed(String authurl, String flwRef);
-
         void onValidateCardChargeFailed(String flwRef, String responseAsJSON);
 
         void onNoAuthInternationalSuggested(Payload payload);

--- a/raveandroid/src/main/java/com/flutterwave/raveandroid/card/CardFragment.java
+++ b/raveandroid/src/main/java/com/flutterwave/raveandroid/card/CardFragment.java
@@ -542,11 +542,11 @@ public class CardFragment extends Fragment implements View.OnClickListener, Card
     }
 
     /**
-     * Called when the auth model suggested is VBV. It opens a webview
+     * Called when the auth model suggested is VBV. It opens a WebView
      * that loads the authURL
      *
-     * @param authUrlCrude = URL to display in webview
-     * @param flwRef       = reference of the payment transaction
+     * @param authUrlCrude URL to display in webview
+     * @param flwRef Reference of the payment transaction
      */
     @Override
     public void onVBVAuthModelUsed(String authUrlCrude, String flwRef) {
@@ -823,25 +823,6 @@ public class CardFragment extends Fragment implements View.OnClickListener, Card
         intent.putExtra(VerificationActivity.ACTIVITY_MOTIVE, "avsvbv");
         intent.putExtra("theme", ravePayInitializer.getTheme());
         startActivityForResult(intent, FOR_AVBVV);
-    }
-
-    /**
-     * Called when the auth model suggested is AVS_VBVSecureCode. It opens a webview
-     * that loads the authURL
-     *
-     * @param authurl = URL to display in webview
-     * @param flwRef  = reference of the payment transaction
-     */
-    @Override
-    public void onAVSVBVSecureCodeModelUsed(String authurl, String flwRef) {
-        this.flwRef = flwRef;
-        Intent intent = new Intent(getContext(), VerificationActivity.class);
-        intent.putExtra(EXTRA_IS_STAGING, ravePayInitializer.isStaging());
-        intent.putExtra(VerificationActivity.PUBLIC_KEY_EXTRA, ravePayInitializer.getPublicKey());
-        intent.putExtra(WebFragment.EXTRA_AUTH_URL, authurl);
-        intent.putExtra(VerificationActivity.ACTIVITY_MOTIVE, "web");
-        intent.putExtra("theme", ravePayInitializer.getTheme());
-        startActivityForResult(intent, FOR_INTERNET_BANKING);
     }
 
     private class ExpiryWatcher implements TextWatcher {

--- a/raveandroid/src/main/java/com/flutterwave/raveandroid/card/CardPresenter.java
+++ b/raveandroid/src/main/java/com/flutterwave/raveandroid/card/CardPresenter.java
@@ -246,42 +246,7 @@ public class CardPresenter implements CardContract.UserActionsListener {
     public void chargeSavedCard(Payload payload, String encryptionKey) {
         if (payload.getOtp() == null || payload.getOtp() == "") {
             sendRaveOTP(payload);
-        } else {
-            // Charge saved card
-            String cardRequestBodyAsString = Utils.convertChargeRequestPayloadToJson(payload);
-            String encryptedCardRequestBody = Utils.getEncryptedData(cardRequestBodyAsString, encryptionKey);
-
-            final ChargeRequestBody body = new ChargeRequestBody();
-            body.setAlg("3DES-24");
-            body.setPBFPubKey(payload.getPBFPubKey());
-            body.setClient(encryptedCardRequestBody);
-
-            mView.showProgressIndicator(true);
-
-            networkRequest.charge(body, new Callbacks.OnChargeRequestComplete() {
-                @Override
-                public void onSuccess(ChargeResponse response, String responseAsJSONString) {
-
-                    mView.showProgressIndicator(false);
-
-                    if (response.getData() != null) {
-                        Log.d("Saved card charge", responseAsJSONString);
-                        mView.onChargeCardSuccessful(response);
-
-                    } else {
-                        mView.onPaymentError("No response data was returned");
-                    }
-
-                }
-
-                @Override
-                public void onError(String message, String responseAsJSONString) {
-
-                    mView.showProgressIndicator(false);
-                    mView.onPaymentError(message);
-                }
-            });
-        }
+        } else chargeCard(payload, encryptionKey);
     }
 
     @Override

--- a/raveandroid/src/main/java/com/flutterwave/raveandroid/card/CardPresenter.java
+++ b/raveandroid/src/main/java/com/flutterwave/raveandroid/card/CardPresenter.java
@@ -549,7 +549,7 @@ public class CardPresenter implements CardContract.UserActionsListener {
 
 
     @Override
-    public void chargeCardWithSuggestedAuthModel(Payload payload, String zipOrPin, String authModel, String encryptionKey) {
+    public void chargeCardWithSuggestedAuthModel(final Payload payload, String zipOrPin, String authModel, String encryptionKey) {
 
         if (authModel.equalsIgnoreCase(AVS_VBVSECURECODE)) {
             payload.setBillingzip(zipOrPin);
@@ -595,6 +595,22 @@ public class CardPresenter implements CardContract.UserActionsListener {
                         } else if (authModelUsed.equalsIgnoreCase(AVS_VBVSECURECODE)) {
                             String flwRef = response.getData().getFlwRef();
                             mView.onAVSVBVSecureCodeModelUsed(response.getData().getAuthurl(), flwRef);
+                        } else if (authModelUsed.equalsIgnoreCase(VBV)) {
+                            String authUrlCrude = response.getData().getAuthurl();
+                            String flwRef = response.getData().getFlwRef();
+
+                            mView.onVBVAuthModelUsed(authUrlCrude, flwRef);
+                        } else if (authModelUsed.equalsIgnoreCase(GTB_OTP)
+                                || authModelUsed.equalsIgnoreCase(ACCESS_OTP)
+                                || authModelUsed.toLowerCase().contains("otp")) {
+                            String flwRef = response.getData().getFlwRef();
+                            String chargeResponseMessage = response.getData().getChargeResponseMessage();
+                            chargeResponseMessage = chargeResponseMessage == null ? enterOTP : chargeResponseMessage;
+                            mView.showOTPLayout(flwRef, chargeResponseMessage);
+
+                        } else if (authModelUsed.equalsIgnoreCase(NOAUTH)) {
+                            String flwRef = response.getData().getFlwRef();
+                            mView.onNoAuthUsed(flwRef, payload.getPBFPubKey());
                         } else {
                             mView.onPaymentError(unknownAuthmsg);
                         }

--- a/raveandroid/src/main/java/com/flutterwave/raveandroid/card/CardPresenter.java
+++ b/raveandroid/src/main/java/com/flutterwave/raveandroid/card/CardPresenter.java
@@ -66,14 +66,12 @@ import static com.flutterwave.raveandroid.RaveConstants.fieldCardExpiry;
 import static com.flutterwave.raveandroid.RaveConstants.fieldCvv;
 import static com.flutterwave.raveandroid.RaveConstants.fieldEmail;
 import static com.flutterwave.raveandroid.RaveConstants.fieldcardNoStripped;
-import static com.flutterwave.raveandroid.RaveConstants.invalidChargeCode;
 import static com.flutterwave.raveandroid.RaveConstants.noResponse;
 import static com.flutterwave.raveandroid.RaveConstants.success;
 import static com.flutterwave.raveandroid.RaveConstants.tokenExpired;
 import static com.flutterwave.raveandroid.RaveConstants.tokenNotFound;
 import static com.flutterwave.raveandroid.RaveConstants.transactionError;
 import static com.flutterwave.raveandroid.RaveConstants.unknownAuthmsg;
-import static com.flutterwave.raveandroid.RaveConstants.unknownResCodemsg;
 import static com.flutterwave.raveandroid.RaveConstants.validAmountPrompt;
 import static com.flutterwave.raveandroid.RaveConstants.validCreditCardPrompt;
 import static com.flutterwave.raveandroid.RaveConstants.validCvvPrompt;
@@ -134,7 +132,7 @@ public class CardPresenter implements CardContract.UserActionsListener {
         this.context = context;
     }
 
-    public CardPresenter(Context context, CardContract.View mView, AppComponent appComponent){
+    public CardPresenter(Context context, CardContract.View mView, AppComponent appComponent) {
         this.context = context;
         this.mView = mView;
         this.eventLogger = appComponent.eventLogger();
@@ -152,6 +150,13 @@ public class CardPresenter implements CardContract.UserActionsListener {
         this.gson = appComponent.gson();
     }
 
+    /**
+     * Makes a generic call to the charge endpoint with the payload provided. Handles both conditions
+     * for initial charge request and when the suggested auth has been added.
+     *
+     * @param payload       {@link Payload} object to be sent.
+     * @param encryptionKey Rave encryption key gotten from dashboard
+     */
     @Override
     public void chargeCard(final Payload payload, final String encryptionKey) {
 
@@ -189,33 +194,44 @@ public class CardPresenter implements CardContract.UserActionsListener {
                             mView.onPaymentError(unknownAuthmsg);
                         }
                     } else {
-                        String authModelUsed = response.getData().getAuthModelUsed();
+                        // Check if transaction is already successful
+                        if (response.getData().getChargeResponseCode() != null && response.getData().getChargeResponseCode().equalsIgnoreCase("00")) {
+                            mView.onChargeCardSuccessful(response);
 
-                        if (authModelUsed != null) {
+                        } else {
 
-                            if (authModelUsed.equalsIgnoreCase(VBV)) {
-                                String authUrlCrude = response.getData().getAuthurl();
-                                String flwRef = response.getData().getFlwRef();
+                            String authModelUsed = response.getData().getAuthModelUsed();
 
-                                mView.onVBVAuthModelUsed(authUrlCrude, flwRef);
-                            } else if (authModelUsed.equalsIgnoreCase(GTB_OTP)
-                                    || authModelUsed.equalsIgnoreCase(ACCESS_OTP)
-                                    || authModelUsed.toLowerCase().contains("otp")) {
-                                String flwRef = response.getData().getFlwRef();
-                                String chargeResponseMessage = response.getData().getChargeResponseMessage();
-                                chargeResponseMessage = chargeResponseMessage == null ? enterOTP : chargeResponseMessage;
-                                mView.showOTPLayout(flwRef, chargeResponseMessage);
+                            if (authModelUsed != null) {
 
-                            } else if (authModelUsed.equalsIgnoreCase(NOAUTH)) {
-                                String flwRef = response.getData().getFlwRef();
-                                mView.onNoAuthUsed(flwRef, payload.getPBFPubKey());
+                                if (authModelUsed.equalsIgnoreCase(VBV) || authModelUsed.equalsIgnoreCase(AVS_VBVSECURECODE)) {
+                                    String authUrlCrude = response.getData().getAuthurl();
+                                    String flwRef = response.getData().getFlwRef();
+
+                                    mView.onVBVAuthModelUsed(authUrlCrude, flwRef);
+                                } else if (authModelUsed.equalsIgnoreCase(GTB_OTP)
+                                        || authModelUsed.equalsIgnoreCase(ACCESS_OTP)
+                                        || authModelUsed.toLowerCase().contains("otp")
+                                        || authModelUsed.equalsIgnoreCase(PIN)) {
+                                    String flwRef = response.getData().getFlwRef();
+                                    String chargeResponseMessage = response.getData().getChargeResponseMessage();
+                                    chargeResponseMessage = (chargeResponseMessage == null || chargeResponseMessage.length() == 0) ? enterOTP : chargeResponseMessage;
+                                    mView.showOTPLayout(flwRef, chargeResponseMessage);
+
+                                } else if (authModelUsed.equalsIgnoreCase(NOAUTH)) {
+                                    String flwRef = response.getData().getFlwRef();
+                                    mView.onNoAuthUsed(flwRef, payload.getPBFPubKey());
+                                } else {
+                                    mView.onPaymentError(unknownAuthmsg);
+                                }
+                            } else {
+                                mView.onPaymentError(unknownAuthmsg);
                             }
                         }
                     }
                 } else {
                     mView.onPaymentError(noResponse);
                 }
-
             }
 
             @Override
@@ -305,61 +321,9 @@ public class CardPresenter implements CardContract.UserActionsListener {
         payload.setBillingcountry(country);
         payload.setBillingstate(state);
 
-        String cardRequestBodyAsString = Utils.convertChargeRequestPayloadToJson(payload);
-        String encryptedCardRequestBody = payloadEncryptor.getEncryptedData(cardRequestBodyAsString, encryptionKey).trim().replaceAll("\\n", "");
-
-        ChargeRequestBody body = new ChargeRequestBody();
-        body.setAlg("3DES-24");
-        body.setPBFPubKey(payload.getPBFPubKey());
-        body.setClient(encryptedCardRequestBody);
-
-        mView.showProgressIndicator(true);
-
-
         logEvent(new ChargeAttemptEvent("AVS Card").getEvent(), payload.getPBFPubKey());
 
-
-        networkRequest.charge(body, new Callbacks.OnChargeRequestComplete() {
-
-            @Override
-            public void onSuccess(ChargeResponse response, String responseAsJSONString) {
-
-                mView.showProgressIndicator(false);
-
-                if (response.getData() != null && response.getData().getChargeResponseCode() != null) {
-                    String chargeResponseCode = response.getData().getChargeResponseCode();
-
-                    if (chargeResponseCode.equalsIgnoreCase("00")) {
-                        mView.onChargeCardSuccessful(response);
-                    } else if (chargeResponseCode.equalsIgnoreCase("02")) {
-                        String authModelUsed = response.getData().getAuthModelUsed();
-
-                        if (authModelUsed.equalsIgnoreCase(PIN)) {
-                            String flwRef = response.getData().getFlwRef();
-                            String chargeResponseMessage = response.getData().getChargeResponseMessage();
-                            chargeResponseMessage = (chargeResponseMessage == null || chargeResponseMessage.length() == 0) ? enterOTP : chargeResponseMessage;
-                            mView.showOTPLayout(flwRef, chargeResponseMessage);
-                        } else if (authModelUsed.equalsIgnoreCase(VBV)) {
-                            String flwRef = response.getData().getFlwRef();
-                            mView.onAVSVBVSecureCodeModelUsed(response.getData().getAuthurl(), flwRef);
-                        } else {
-                            mView.onPaymentError(unknownAuthmsg);
-                        }
-                    } else {
-                        mView.onPaymentError(unknownResCodemsg);
-                    }
-                } else {
-                    mView.onPaymentError(invalidChargeCode);
-                }
-
-            }
-
-            @Override
-            public void onError(String message, String responseAsJSONString) {
-                mView.showProgressIndicator(false);
-                mView.onPaymentError(message);
-            }
-        });
+        chargeCard(payload, encryptionKey);
 
     }
 
@@ -559,76 +523,7 @@ public class CardPresenter implements CardContract.UserActionsListener {
 
         payload.setSuggestedAuth(authModel);
 
-        String cardRequestBodyAsString = Utils.convertChargeRequestPayloadToJson(payload);
-        String encryptedCardRequestBody = payloadEncryptor.getEncryptedData(cardRequestBodyAsString, encryptionKey).trim().replaceAll("\\n", "");
-
-        ChargeRequestBody body = new ChargeRequestBody();
-        body.setAlg("3DES-24");
-        body.setPBFPubKey(payload.getPBFPubKey());
-        body.setClient(encryptedCardRequestBody);
-
-        mView.showProgressIndicator(true);
-
-        logEvent(new ChargeAttemptEvent("Card").getEvent(), payload.getPBFPubKey());
-
-
-        networkRequest.charge(body, new Callbacks.OnChargeRequestComplete() {
-            @Override
-            public void onSuccess(ChargeResponse response, String responseAsJSONString) {
-
-                mView.showProgressIndicator(false);
-
-                if (response.getData() != null && response.getData().getChargeResponseCode() != null) {
-                    String chargeResponseCode = response.getData().getChargeResponseCode();
-
-                    if (chargeResponseCode.equalsIgnoreCase("00")) {
-                        mView.onChargeCardSuccessful(response);
-                    } else if (chargeResponseCode.equalsIgnoreCase("02")) {
-
-                        String authModelUsed = response.getData().getAuthModelUsed();
-
-                        if (authModelUsed.equalsIgnoreCase(PIN)) {
-                            String flwRef = response.getData().getFlwRef();
-                            String chargeResponseMessage = response.getData().getChargeResponseMessage();
-                            chargeResponseMessage = (chargeResponseMessage == null || chargeResponseMessage.length() == 0) ? "Enter your one  time password (OTP)" : chargeResponseMessage;
-                            mView.showOTPLayout(flwRef, chargeResponseMessage);
-                        } else if (authModelUsed.equalsIgnoreCase(AVS_VBVSECURECODE)) {
-                            String flwRef = response.getData().getFlwRef();
-                            mView.onAVSVBVSecureCodeModelUsed(response.getData().getAuthurl(), flwRef);
-                        } else if (authModelUsed.equalsIgnoreCase(VBV)) {
-                            String authUrlCrude = response.getData().getAuthurl();
-                            String flwRef = response.getData().getFlwRef();
-
-                            mView.onVBVAuthModelUsed(authUrlCrude, flwRef);
-                        } else if (authModelUsed.equalsIgnoreCase(GTB_OTP)
-                                || authModelUsed.equalsIgnoreCase(ACCESS_OTP)
-                                || authModelUsed.toLowerCase().contains("otp")) {
-                            String flwRef = response.getData().getFlwRef();
-                            String chargeResponseMessage = response.getData().getChargeResponseMessage();
-                            chargeResponseMessage = chargeResponseMessage == null ? enterOTP : chargeResponseMessage;
-                            mView.showOTPLayout(flwRef, chargeResponseMessage);
-
-                        } else if (authModelUsed.equalsIgnoreCase(NOAUTH)) {
-                            String flwRef = response.getData().getFlwRef();
-                            mView.onNoAuthUsed(flwRef, payload.getPBFPubKey());
-                        } else {
-                            mView.onPaymentError(unknownAuthmsg);
-                        }
-                    } else {
-                        mView.onPaymentError(unknownResCodemsg);
-                    }
-                } else {
-                    mView.onPaymentError(invalidChargeCode);
-                }
-
-            }
-
-            @Override
-            public void onError(String message, String responseAsJSONString) {
-                mView.showProgressIndicator(false);
-                mView.onPaymentError(message);
-            }
-        });
+        chargeCard(payload, encryptionKey);
 
     }
 

--- a/raveandroid/src/main/java/com/flutterwave/raveandroid/card/NullCardView.java
+++ b/raveandroid/src/main/java/com/flutterwave/raveandroid/card/NullCardView.java
@@ -188,11 +188,6 @@ public class NullCardView implements View.OnClickListener, CardContract.View {
     }
 
     @Override
-    public void onAVSVBVSecureCodeModelUsed(String authurl, String flwRef) {
-
-    }
-
-    @Override
     public void onValidateCardChargeFailed(String flwRef, String responseAsJSON) {
 
     }

--- a/raveandroid/src/test/java/com/flutterwave/raveandroid/card/CardPresenterTest.java
+++ b/raveandroid/src/test/java/com/flutterwave/raveandroid/card/CardPresenterTest.java
@@ -58,14 +58,12 @@ import static com.flutterwave.raveandroid.RaveConstants.fieldCardExpiry;
 import static com.flutterwave.raveandroid.RaveConstants.fieldCvv;
 import static com.flutterwave.raveandroid.RaveConstants.fieldEmail;
 import static com.flutterwave.raveandroid.RaveConstants.fieldcardNoStripped;
-import static com.flutterwave.raveandroid.RaveConstants.invalidChargeCode;
 import static com.flutterwave.raveandroid.RaveConstants.noResponse;
 import static com.flutterwave.raveandroid.RaveConstants.success;
 import static com.flutterwave.raveandroid.RaveConstants.tokenExpired;
 import static com.flutterwave.raveandroid.RaveConstants.tokenNotFound;
 import static com.flutterwave.raveandroid.RaveConstants.transactionError;
 import static com.flutterwave.raveandroid.RaveConstants.unknownAuthmsg;
-import static com.flutterwave.raveandroid.RaveConstants.unknownResCodemsg;
 import static com.flutterwave.raveandroid.RaveConstants.validExpiryDatePrompt;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -870,7 +868,7 @@ public class CardPresenterTest {
         cardPresenter.chargeCardWithSuggestedAuthModel(generatePayload(), generateRandomString(), generateRandomString(), generateRandomString());
         ArgumentCaptor<Callbacks.OnChargeRequestComplete> captor = ArgumentCaptor.forClass(Callbacks.OnChargeRequestComplete.class);
         verify(networkRequest).charge(any(ChargeRequestBody.class), captor.capture());
-        captor.getAllValues().get(0).onSuccess(generateValidChargeResponseWithAuth(PIN), generateRandomString());
+        captor.getAllValues().get(0).onSuccess(generateValidChargeResponseWithAuthModelUsed(PIN), generateRandomString());
         verify(view).showOTPLayout(anyString(), anyString());
 
     }
@@ -881,8 +879,8 @@ public class CardPresenterTest {
         cardPresenter.chargeCardWithSuggestedAuthModel(generatePayload(), generateRandomString(), generateRandomString(), generateRandomString());
         ArgumentCaptor<Callbacks.OnChargeRequestComplete> captor = ArgumentCaptor.forClass(Callbacks.OnChargeRequestComplete.class);
         verify(networkRequest).charge(any(ChargeRequestBody.class), captor.capture());
-        captor.getAllValues().get(0).onSuccess(generateValidChargeResponseWithAuth(AVS_VBVSECURECODE), generateRandomString());
-        verify(view).onAVSVBVSecureCodeModelUsed(anyString(), anyString());
+        captor.getAllValues().get(0).onSuccess(generateValidChargeResponseWithAuthModelUsed(AVS_VBVSECURECODE), generateRandomString());
+        verify(view).onVBVAuthModelUsed(anyString(), anyString());
 
     }
 
@@ -894,7 +892,7 @@ public class CardPresenterTest {
         ArgumentCaptor<Callbacks.OnChargeRequestComplete> captor = ArgumentCaptor.forClass(Callbacks.OnChargeRequestComplete.class);
         verify(networkRequest).charge(any(ChargeRequestBody.class), captor.capture());
         captor.getAllValues().get(0).onSuccess(generateRandomChargeResponse(), generateRandomString());
-        verify(view).onPaymentError(unknownResCodemsg);
+        verify(view).onPaymentError(anyString());
 
     }
 
@@ -916,7 +914,7 @@ public class CardPresenterTest {
         ArgumentCaptor<Callbacks.OnChargeRequestComplete> captor = ArgumentCaptor.forClass(Callbacks.OnChargeRequestComplete.class);
         verify(networkRequest).charge(any(ChargeRequestBody.class), captor.capture());
         captor.getAllValues().get(0).onSuccess(generateNullChargeResponse(), generateRandomString());
-        verify(view).onPaymentError(invalidChargeCode);
+        verify(view).onPaymentError(anyString());
 
     }
 
@@ -997,7 +995,7 @@ public class CardPresenterTest {
         captor.getAllValues().get(0).onSuccess(chargeResponse, generateRandomString());
 
         //assert
-        verify(view).onAVSVBVSecureCodeModelUsed(authurl, flwref);
+        verify(view).onVBVAuthModelUsed(authurl, flwref);
 
     }
 
@@ -1015,7 +1013,7 @@ public class CardPresenterTest {
         captor.getAllValues().get(0).onSuccess(generateRandomChargeResponse(), generateRandomString());
 
         //assert
-        verify(view).onPaymentError(unknownResCodemsg);
+        verify(view).onPaymentError(anyString());
 
     }
 
@@ -1049,7 +1047,7 @@ public class CardPresenterTest {
         captor.getAllValues().get(0).onSuccess(generateNullChargeResponse(), generateRandomString());
 
         //assert
-        verify(view).onPaymentError(invalidChargeCode);
+        verify(view).onPaymentError(any(String.class));
 
     }
 
@@ -1133,6 +1131,15 @@ public class CardPresenterTest {
         ChargeResponse chargeResponse = generateRandomChargeResponse();
         chargeResponse.getData().setAuthModelUsed(auth);
         chargeResponse.getData().setSuggested_auth(auth);
+        chargeResponse.getData().setAuthurl(generateRandomString());
+        chargeResponse.getData().setFlwRef(generateRandomString());
+        chargeResponse.getData().setChargeResponseCode("02");
+        return chargeResponse;
+    }
+
+    private ChargeResponse generateValidChargeResponseWithAuthModelUsed(String auth) {
+        ChargeResponse chargeResponse = generateRandomChargeResponse();
+        chargeResponse.getData().setAuthModelUsed(auth);
         chargeResponse.getData().setAuthurl(generateRandomString());
         chargeResponse.getData().setFlwRef(generateRandomString());
         chargeResponse.getData().setChargeResponseCode("02");


### PR DESCRIPTION
When a transaction fails with one auth Model, Rave sometimes tries another authModel.
This commit catches more auth models after the first charge with Auth model.

To test, use 5531886652142950 (PIN) test card with a wrong PIN, it will then redirect to VBV. Previously it would have resulted in, "Unknown Auth Model" error, but now it rightly shows the VBV page.