### PR TITLE
fix/add-full-response-for-card-onSuccessful

### DIFF
--- a/rave_presentation/src/main/java/com/flutterwave/raveandroid/rave_presentation/card/CardInteractorImpl.java
+++ b/rave_presentation/src/main/java/com/flutterwave/raveandroid/rave_presentation/card/CardInteractorImpl.java
@@ -67,7 +67,7 @@ class CardInteractorImpl implements CardContract.CardInteractor {
     @Override
     public void onPaymentSuccessful(String status, String flwRef, String responseAsJSONString) {
         this.flwRef = flwRef;
-        callback.onSuccessful(flwRef);
+        callback.onSuccessful(flwRef, responseAsJSONString);
     }
 
     @Override

--- a/rave_presentation/src/main/java/com/flutterwave/raveandroid/rave_presentation/card/CardPaymentCallback.java
+++ b/rave_presentation/src/main/java/com/flutterwave/raveandroid/rave_presentation/card/CardPaymentCallback.java
@@ -62,5 +62,5 @@ public interface CardPaymentCallback {
      *
      * @param flwRef The Flutterwave reference to the transaction.
      */
-    void onSuccessful(String flwRef);
+    void onSuccessful(String flwRef, @Nullable String responseAsJSONString);
 }


### PR DESCRIPTION
in case we need more data from response, and onActivityResult isn't working with react native native modules